### PR TITLE
Fix cmake: remove binary dir from include directories

### DIFF
--- a/source/glkernel/CMakeLists.txt
+++ b/source/glkernel/CMakeLists.txt
@@ -81,7 +81,6 @@ target_include_directories(${target}
 
     INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
 
     ${DEFAULT_INCLUDE_DIRECTORIES}


### PR DESCRIPTION
because @scheibel told me to do so. without this fix, multiframerendering didn't build.