### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     compiler: gcc
 
 before_install:
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq cmake libglm-dev cppcheck clang-tidy-3.8; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq cmake libglm-dev cppcheck clang-tidy-3.8 libomp-dev; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install glm cppcheck; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,3 @@ before_script:
 script:
   - cmake --build $BUILD_DIR
   - cmake --build $BUILD_DIR --target test
-  - cmake --build $BUILD_DIR --target check-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ compiler:
 
 env:
   global:
-    - CMAKE_OPTIONS="-DOPTION_BUILD_EXAMPLES=On"
+    - CMAKE_OPTIONS="-DOPTION_BUILD_EXAMPLES=On -DOPTION_USE_OMP=OFF"
   matrix:
     - CMAKE_CONFIGURATION=release BUILD_DIR=build
     - CMAKE_CONFIGURATION=debug BUILD_DIR=build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ compiler:
 
 env:
   global:
-    - CMAKE_OPTIONS="-DOPTION_BUILD_EXAMPLES=On -DOPTION_USE_OMP=OFF"
+    - CMAKE_OPTIONS="-DOPTION_BUILD_EXAMPLES=On"
   matrix:
     - CMAKE_CONFIGURATION=release BUILD_DIR=build
     - CMAKE_CONFIGURATION=debug BUILD_DIR=build-debug
@@ -26,6 +26,7 @@ matrix:
 before_install:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq cmake libglm-dev cppcheck clang-tidy-3.8; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install glm cppcheck; fi
+  - if [ ($TRAVIS_OS_NAME == linux) && ($CXX == "clang++") ]; then CMAKE_OPTIONS=$CMAKE_OPTIONS" -DOPTION_USE_OMP=Off"
 
 before_script:
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     compiler: gcc
 
 before_install:
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq cmake libglm-dev cppcheck clang-tidy-3.8 libomp-dev; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq cmake libglm-dev cppcheck clang-tidy-3.8; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install glm cppcheck; fi
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(OPTION_BUILD_TESTS    "Build tests."                                     
 option(OPTION_BUILD_DOCS     "Build documentation."                                   OFF)
 option(OPTION_BUILD_EXAMPLES "Build examples."                                        OFF)
 option(OPTION_BUILD_TOOLS    "Build tools."                                           OFF)
+option(OPTION_USE_OMP        "Whether or not to compile against OMP"                  ON)
 
 
 # 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ option(OPTION_SELF_CONTAINED "Create a self-contained install with all dependenc
 option(OPTION_BUILD_TESTS    "Build tests."                                           ON)
 option(OPTION_BUILD_DOCS     "Build documentation."                                   OFF)
 option(OPTION_BUILD_EXAMPLES "Build examples."                                        OFF)
-option(OPTION_BUILD_TOOLS    "Build tools."                                           ON)
+option(OPTION_BUILD_TOOLS    "Build tools."                                           OFF)
 
 
 # 

--- a/source/glkernel/include/glkernel/sample.hpp
+++ b/source/glkernel/include/glkernel/sample.hpp
@@ -421,7 +421,7 @@ glm::tvec3<T, P> hemisphere_sample_uniform(const T u, const T v)
     const T phi = v * 2 * glm::pi<T>();
     const T cosTheta = 1 - u;
     const T sinTheta = sqrt(1 - cosTheta * cosTheta);
-    return { cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta };
+    return glm::tvec3<T, P>{ cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta };
 }
 
 template <typename T, glm::precision P>

--- a/source/glkernel/include/glkernel/sample.hpp
+++ b/source/glkernel/include/glkernel/sample.hpp
@@ -181,7 +181,7 @@ size_t poisson_square(tkernel<glm::tvec2<T, P>> & kernel, const T min_dist, cons
         }
         
         // pick nearest probe from sample set
-        glm::vec2 nearest_probe;
+        glm::tvec2<T, P> nearest_probe;
         auto nearest_dist = 4 * min_dist * min_dist;
         auto nearest_found = false;
 

--- a/source/glkernel/include/glkernel/sample.hpp
+++ b/source/glkernel/include/glkernel/sample.hpp
@@ -430,7 +430,7 @@ glm::tvec3<T, P> hemisphere_sample_cos(const T u, const T v)
     const T phi = v * 2 * glm::pi<T>();
     const T cosTheta = sqrt(1 - u);
     const T sinTheta = sqrt(1 - cosTheta * cosTheta);
-    return { cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta };
+    return glm::tvec3<T, P>{ cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta };
 }
 
 } // anonymous namespace

--- a/source/glkernel/include/glkernel/sort.hpp
+++ b/source/glkernel/include/glkernel/sort.hpp
@@ -20,8 +20,8 @@ template <typename T>
 struct distance_comparator
 {
     distance_comparator(const T & origin)
+    : m_origin(origin)
     {
-        m_origin = origin;
     }
 
     bool operator()(const T & a, const T & b) const

--- a/source/glkernel/include/glkernel/sort.hpp
+++ b/source/glkernel/include/glkernel/sort.hpp
@@ -20,8 +20,8 @@ template <typename T>
 struct distance_comparator
 {
     distance_comparator(const T & origin)
-    : m_origin {origin}
     {
+        m_origin = origin;
     }
 
     bool operator()(const T & a, const T & b) const

--- a/source/tests/glkernel-test/CMakeLists.txt
+++ b/source/tests/glkernel-test/CMakeLists.txt
@@ -19,7 +19,11 @@ if (NOT OPENMP_FOUND AND NOT OpenMP_FOUND)
     message("Loop parallelization in ${target} skipped: OpenMP not found")
     set(OpenMP_SUPPORTED FALSE)
 else()
-    set(OpenMP_SUPPORTED TRUE)
+    if(USE_OPENMP)
+        set(OpenMP_SUPPORTED TRUE)
+    else()
+        set(OpenMP_SUPPORTED FALSE)
+    endif()
 endif()
 
 

--- a/source/tests/glkernel-test/noise_test.cpp
+++ b/source/tests/glkernel-test/noise_test.cpp
@@ -58,9 +58,9 @@ TEST_F(noise_test, uniform_compile)
     glkernel::noise::uniform(fkernel3, 0.f, 1.f);
     glkernel::noise::uniform(fkernel4, 0.f, 1.f);
 
-    glkernel::noise::uniform(fkernel2, glm::vec2{ 0.f }, glm::vec2{ 1.f });
-    glkernel::noise::uniform(fkernel3, glm::vec3{ 0.f }, glm::vec3{ 1.f });
-    glkernel::noise::uniform(fkernel4, glm::vec4{ 0.f }, glm::vec4{ 1.f });
+    glkernel::noise::uniform(fkernel2, glm::vec2( 0.f ), glm::vec2( 1.f ));
+    glkernel::noise::uniform(fkernel3, glm::vec3( 0.f ), glm::vec3( 1.f ));
+    glkernel::noise::uniform(fkernel4, glm::vec4( 0.f ), glm::vec4( 1.f ));
 
     auto dkernel1 = glkernel::dkernel1{ 1 };
     auto dkernel2 = glkernel::dkernel2{ 1 };
@@ -72,9 +72,9 @@ TEST_F(noise_test, uniform_compile)
     glkernel::noise::uniform(dkernel3, 0.0, 1.0);
     glkernel::noise::uniform(dkernel4, 0.0, 1.0);
 
-    glkernel::noise::uniform(dkernel2, glm::dvec2{ 0.0 }, glm::dvec2{ 1.0 });
-    glkernel::noise::uniform(dkernel3, glm::dvec3{ 0.0 }, glm::dvec3{ 1.0 });
-    glkernel::noise::uniform(dkernel4, glm::dvec4{ 0.0 }, glm::dvec4{ 1.0 });
+    glkernel::noise::uniform(dkernel2, glm::dvec2( 0.0 ), glm::dvec2( 1.0 ));
+    glkernel::noise::uniform(dkernel3, glm::dvec3( 0.0 ), glm::dvec3( 1.0 ));
+    glkernel::noise::uniform(dkernel4, glm::dvec4( 0.0 ), glm::dvec4( 1.0 ));
 }
 
 TEST_F(noise_test, gradient_compile)

--- a/source/tests/glkernel-test/noise_test.cpp
+++ b/source/tests/glkernel-test/noise_test.cpp
@@ -23,8 +23,8 @@ TEST_F(noise_test, normal_compile)
     auto fkernel4 = glkernel::kernel4{ 1 };
 
     glkernel::noise::normal(fkernel1, 0.f, 1.f);
-    glkernel::noise::normal(fkernel2, 0.f, 1.f);
     glkernel::noise::normal(fkernel3, 0.f, 1.f);
+    glkernel::noise::normal(fkernel2, 0.f, 1.f);
     glkernel::noise::normal(fkernel4, 0.f, 1.f);
 
     glkernel::noise::normal(fkernel2, glm::vec2{ 0.f }, glm::vec2{ 1.f });

--- a/source/tests/glkernel-test/noise_test.cpp
+++ b/source/tests/glkernel-test/noise_test.cpp
@@ -18,8 +18,8 @@ class noise_test: public testing::Test
 TEST_F(noise_test, normal_compile)
 {
     auto fkernel1 = glkernel::kernel1{ 1 };
-    // auto fkernel2 = glkernel::kernel2{ 1 };
     auto fkernel3 = glkernel::kernel3{ 1 };
+    auto fkernel2 = glkernel::kernel2{ 1 };
     auto fkernel4 = glkernel::kernel4{ 1 };
 
     glkernel::noise::normal(fkernel1, 0.f, 1.f);

--- a/source/tests/glkernel-test/noise_test.cpp
+++ b/source/tests/glkernel-test/noise_test.cpp
@@ -18,7 +18,7 @@ class noise_test: public testing::Test
 TEST_F(noise_test, normal_compile)
 {
     auto fkernel1 = glkernel::kernel1{ 1 };
-    auto fkernel2 = glkernel::kernel2{ 1 };
+    // auto fkernel2 = glkernel::kernel2{ 1 };
     auto fkernel3 = glkernel::kernel3{ 1 };
     auto fkernel4 = glkernel::kernel4{ 1 };
 

--- a/source/tests/glkernel-test/noise_test.cpp
+++ b/source/tests/glkernel-test/noise_test.cpp
@@ -18,18 +18,18 @@ class noise_test: public testing::Test
 TEST_F(noise_test, normal_compile)
 {
     auto fkernel1 = glkernel::kernel1{ 1 };
-    auto fkernel3 = glkernel::kernel3{ 1 };
     auto fkernel2 = glkernel::kernel2{ 1 };
+    auto fkernel3 = glkernel::kernel3{ 1 };
     auto fkernel4 = glkernel::kernel4{ 1 };
 
     glkernel::noise::normal(fkernel1, 0.f, 1.f);
-    glkernel::noise::normal(fkernel3, 0.f, 1.f);
     glkernel::noise::normal(fkernel2, 0.f, 1.f);
+    glkernel::noise::normal(fkernel3, 0.f, 1.f);
     glkernel::noise::normal(fkernel4, 0.f, 1.f);
 
-    glkernel::noise::normal(fkernel2, glm::vec2{ 0.f }, glm::vec2{ 1.f });
-    glkernel::noise::normal(fkernel3, glm::vec3{ 0.f }, glm::vec3{ 1.f });
-    glkernel::noise::normal(fkernel4, glm::vec4{ 0.f }, glm::vec4{ 1.f });
+    glkernel::noise::normal(fkernel2, glm::vec2( 0.f ), glm::vec2( 1.f ));
+    glkernel::noise::normal(fkernel3, glm::vec3( 0.f ), glm::vec3( 1.f ));
+    glkernel::noise::normal(fkernel4, glm::vec4( 0.f ), glm::vec4( 1.f ));
 
     auto dkernel1 = glkernel::dkernel1{ 1 };
     auto dkernel2 = glkernel::dkernel2{ 1 };

--- a/source/tests/glkernel-test/noise_test.cpp
+++ b/source/tests/glkernel-test/noise_test.cpp
@@ -41,9 +41,9 @@ TEST_F(noise_test, normal_compile)
     glkernel::noise::normal(dkernel3, 0.0, 1.0);
     glkernel::noise::normal(dkernel4, 0.0, 1.0);
 
-    glkernel::noise::normal(dkernel2, glm::dvec2{ 0.0 }, glm::dvec2{ 1.0 });
-    glkernel::noise::normal(dkernel3, glm::dvec3{ 0.0 }, glm::dvec3{ 1.0 });
-    glkernel::noise::normal(dkernel4, glm::dvec4{ 0.0 }, glm::dvec4{ 1.0 });
+    glkernel::noise::normal(dkernel2, glm::dvec2( 0.0 ), glm::dvec2( 1.0 ));
+    glkernel::noise::normal(dkernel3, glm::dvec3( 0.0 ), glm::dvec3( 1.0 ));
+    glkernel::noise::normal(dkernel4, glm::dvec4( 0.0 ), glm::dvec4( 1.0 ));
 }
 
 TEST_F(noise_test, uniform_compile)

--- a/source/tests/glkernel-test/sequence_test.cpp
+++ b/source/tests/glkernel-test/sequence_test.cpp
@@ -27,9 +27,9 @@ TEST_F(sequence_test, uniform_compile)
     glkernel::sequence::uniform(fkernel3, 0.f, 1.f);
     glkernel::sequence::uniform(fkernel4, 0.f, 1.f);
 
-    glkernel::sequence::uniform(fkernel2, glm::vec2{ 0.f }, glm::vec2{ 1.f });
-    glkernel::sequence::uniform(fkernel3, glm::vec3{ 0.f }, glm::vec3{ 1.f });
-    glkernel::sequence::uniform(fkernel4, glm::vec4{ 0.f }, glm::vec4{ 1.f });
+    glkernel::sequence::uniform(fkernel2, glm::vec2( 0.f ), glm::vec2( 1.f ));
+    glkernel::sequence::uniform(fkernel3, glm::vec3( 0.f ), glm::vec3( 1.f ));
+    glkernel::sequence::uniform(fkernel4, glm::vec4( 0.f ), glm::vec4( 1.f ));
 
     auto dkernel1 = glkernel::dkernel1{ 1 };
     auto dkernel2 = glkernel::dkernel2{ 1 };
@@ -41,9 +41,9 @@ TEST_F(sequence_test, uniform_compile)
     glkernel::sequence::uniform(dkernel3, 0.0, 1.0);
     glkernel::sequence::uniform(dkernel4, 0.0, 1.0);
 
-    glkernel::sequence::uniform(dkernel2, glm::dvec2{ 0.0 }, glm::dvec2{ 1.0 });
-    glkernel::sequence::uniform(dkernel3, glm::dvec3{ 0.0 }, glm::dvec3{ 1.0 });
-    glkernel::sequence::uniform(dkernel4, glm::dvec4{ 0.0 }, glm::dvec4{ 1.0 });
+    glkernel::sequence::uniform(dkernel2, glm::dvec2( 0.0 ), glm::dvec2( 1.0 ));
+    glkernel::sequence::uniform(dkernel3, glm::dvec3( 0.0 ), glm::dvec3( 1.0 ));
+    glkernel::sequence::uniform(dkernel4, glm::dvec4( 0.0 ), glm::dvec4( 1.0 ));
 }
 
 TEST_F(sequence_test, uniform_distribution)

--- a/source/tests/glkernel-test/sort_test.cpp
+++ b/source/tests/glkernel-test/sort_test.cpp
@@ -16,7 +16,7 @@ public:
 TEST_F(sort_test, distance_compile)
 {
     auto fkernel2 = glkernel::kernel2{ 8, 8, 8 };
-    glkernel::sort::distance(fkernel2, glm::vec2{0, 0});
+    glkernel::sort::distance(fkernel2, glm::vec2(0, 0));
 }
 
 TEST_F(sort_test, distance_sorted)
@@ -26,7 +26,7 @@ TEST_F(sort_test, distance_sorted)
     fkernel2[1] = {1, 1};
     fkernel2[2] = {2, 0};
     fkernel2[3] = {-4, 0};
-    glkernel::sort::distance(fkernel2, {0, 0});
+    glkernel::sort::distance(fkernel2, glm::vec2(0, 0));
 
     EXPECT_FLOAT_EQ(1.f, fkernel2[0][0]);
     EXPECT_FLOAT_EQ(1.f, fkernel2[0][1]);

--- a/source/tests/glkernel-test/sort_test.cpp
+++ b/source/tests/glkernel-test/sort_test.cpp
@@ -16,7 +16,7 @@ public:
 TEST_F(sort_test, distance_compile)
 {
     auto fkernel2 = glkernel::kernel2{ 8, 8, 8 };
-    glkernel::sort::distance(fkernel2, {0, 0});
+    glkernel::sort::distance(fkernel2, glm::vec2{0, 0});
 }
 
 TEST_F(sort_test, distance_sorted)


### PR DESCRIPTION
This PR fixes some issues when building with travis. It works around problems with the used glm version as well as bad behaviour when building with clang and omp under linux.