### PR TITLE
Update sample.hpp

### DIFF
--- a/source/glkernel/include/glkernel/sample.hpp
+++ b/source/glkernel/include/glkernel/sample.hpp
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <tuple>
 #include <algorithm>
+#include <numeric>
 
 #include <glkernel/glm_compatability.h>
 


### PR DESCRIPTION
Compiling with visual studio 15 2017 compiler i got the error below which can be fixed by include numeric.

"...sample.hpp(299): error C3861: 'iota': identifier not found"